### PR TITLE
Add support for multithread build

### DIFF
--- a/1.13.2/Dockerfile
+++ b/1.13.2/Dockerfile
@@ -31,7 +31,7 @@ RUN set -e -x && \
       -DOPENSSL_NO_HEARTBEATS \
       -fstack-protector-strong && \
     make depend && \
-    make && \
+    make -j$(nproc) && \
     make install_sw && \
     apt-get purge -y --auto-remove \
       $build_deps && \
@@ -79,6 +79,7 @@ RUN build_deps="curl gcc libc-dev libevent-dev libexpat1-dev libnghttp2-dev make
         --enable-tfo-server \
         --enable-tfo-client \
         --enable-event-api && \
+    make -j$(nproc) && \
     make install && \
     mv /opt/unbound/etc/unbound/unbound.conf /opt/unbound/etc/unbound/unbound.conf.example && \
     apt-get purge -y --auto-remove \


### PR DESCRIPTION
Hello @mxmartins !

On top you 1.13.2 update, I've changed OpenSSL and Unbound compilation to allow the usage of all processors on build, leading to a better build timing.

Build was tested with following docker-composer.yaml:

```
version: '3.7'

services:
  unbound:
    container_name: unbound-dns
    build:
      context: https://github.com/leleobhz/unbound-docker.git
      dockerfile: 1.13.2/Dockerfile
    container_name: unbound
    ports:
      - "53:53/udp"
      - "53:53/tcp"
    volumes:
      - ./forward-records.conf:/opt/unbound/etc/unbound/forward-records.conf:ro
    restart: unless-stopped
    logging:
      driver: journald
```

Can you please consider merge this patch within you upstream PR?